### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "html"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Frogger#
 [Play it here](http://nate.tarrh.website/frogger/).
-
+[![Run on Repl.it](https://repl.it/badge/github/natetarrh/frogger)](https://repl.it/github/natetarrh/frogger)
 A working version of Frogger playable in the browser, implemented with JavaScript.
 
 All basic scoring methods are present, and the player recieves an additional life when 10,000 points are scored with fewer than 4 frogs left. Frogger moves on canvas using UP, DOWN, LEFT, and RIGHT arrow keys. If frogger collides with a vehicle or water, he loses a life. 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@enigma_dev/frogger).